### PR TITLE
Adds babel-core as a dev dependency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,3 @@ projekt-init.sh
 packages
 client/public
 client/node_modules
-

--- a/client/package.json
+++ b/client/package.json
@@ -21,8 +21,9 @@
     "redux": "^3.3.1"
   },
   "devDependencies": {
-    "babel-loader": "^6.2.4",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-core": "^6.18.0",
+    "babel-loader": "^6.2.7",
+    "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.5.0",
     "html-webpack-plugin": "^2.15.0",
     "react-hot-loader": "^1.3.0",


### PR DESCRIPTION
babel-core is a peer-dependency of babel-loader.

Since NPM 3, peer-dependencies are no longer auto-installed. As such peer-dependencies must be installed explicitly.

Also removes trailing whitespace in .dockerignore.